### PR TITLE
Support EVFILT_USER

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.20.0
+version=0.23.0
 profile=janestreet
 parse-docstrings = true
 wrap-comments = true

--- a/lib/config/config.ml
+++ b/lib/config/config.ml
@@ -12,31 +12,41 @@ let kqueue_available vars =
 
 let () =
   C.main ~name:"kqueue.conf" (fun conf ->
-      let system =
-        C.C_define.import
-          conf
-          ~includes:[ "caml/config.h" ]
-          [ "ARCH_SIXTYFOUR", C.C_define.Type.Switch ]
-      in
-      let operating_systems =
-        C.C_define.import
-          conf
-          ~includes:[]
-          [ "__APPLE__", C.C_define.Type.Switch
-          ; "__FreeBSD__", C.C_define.Type.Switch
-          ; "__OpenBSD__", C.C_define.Type.Switch
-          ; "__DragonFly__", C.C_define.Type.Switch
-          ; "__NetBSD__", C.C_define.Type.Switch
-          ]
-      in
-      let vars =
-        [ "KQUEUE_AVAILABLE", C.C_define.Value.Switch (kqueue_available operating_systems)
-        ; "FREEBSD", List.assoc "__FreeBSD__" operating_systems
-        ; "OPENBSD", List.assoc "__OpenBSD__" operating_systems
-        ; "DRAGONFLY", List.assoc "__DragonFly__" operating_systems
-        ; "NETBSD", List.assoc "__NetBSD__" operating_systems
-        ; "KQUEUE_ML_ARCH_SIXTYFOUR", List.assoc "ARCH_SIXTYFOUR" system
+    let system =
+      C.C_define.import
+        conf
+        ~includes:[ "caml/config.h" ]
+        [ "ARCH_SIXTYFOUR", C.C_define.Type.Switch ]
+    in
+    let evfilt_user_available kqueue_available =
+      let var = "EVFILT_USER" in
+      if kqueue_available
+      then (
+        let check = C.C_define.import conf ~includes:[ "sys/event.h" ] [ var, Switch ] in
+        List.assoc var check)
+      else C.C_define.Value.Switch false
+    in
+    let operating_systems =
+      C.C_define.import
+        conf
+        ~includes:[]
+        [ "__APPLE__", C.C_define.Type.Switch
+        ; "__FreeBSD__", C.C_define.Type.Switch
+        ; "__OpenBSD__", C.C_define.Type.Switch
+        ; "__DragonFly__", C.C_define.Type.Switch
+        ; "__NetBSD__", C.C_define.Type.Switch
         ]
-      in
-      C.C_define.gen_header_file conf ~fname:"config.h" vars)
+    in
+    let is_kqueue_available = kqueue_available operating_systems in
+    let vars =
+      [ "KQUEUE_AVAILABLE", C.C_define.Value.Switch is_kqueue_available
+      ; "FREEBSD", List.assoc "__FreeBSD__" operating_systems
+      ; "OPENBSD", List.assoc "__OpenBSD__" operating_systems
+      ; "DRAGONFLY", List.assoc "__DragonFly__" operating_systems
+      ; "NETBSD", List.assoc "__NetBSD__" operating_systems
+      ; "KQUEUE_ML_ARCH_SIXTYFOUR", List.assoc "ARCH_SIXTYFOUR" system
+      ; "EVFILT_USER_AVAILABLE", evfilt_user_available is_kqueue_available
+      ]
+    in
+    C.C_define.gen_header_file conf ~fname:"config.h" vars)
 ;;

--- a/lib/kqueue_intf.ml
+++ b/lib/kqueue_intf.ml
@@ -1,3 +1,5 @@
+[%%import "config.h"]
+
 module type S = sig
   type t
 
@@ -30,7 +32,6 @@ module type S = sig
         - {{:https://man.openbsd.org/kqueue.2} OpenBSD}*)
     type t
 
-    val pp : Format.formatter -> t -> unit
     val equal : t -> t -> bool
     val ( = ) : t -> t -> bool
     val empty : t
@@ -50,6 +51,18 @@ module type S = sig
     val fork : t
     val exec : t
     val signal : t
+
+    [%%if defined EVFILT_USER_AVAILABLE]
+
+    val ffnop : t
+    val ffand : t
+    val ffor : t
+    val ffcopy : t
+    val ffctrlmask : t
+    val fflagsmask : t
+    val trigger : t
+
+    [%%endif]
   end
 
   module Filter : sig
@@ -64,6 +77,12 @@ module type S = sig
     val timer : t
     val vnode : t
     val proc : t
+
+    [%%if defined EVFILT_USER_AVAILABLE]
+
+    val user : t
+
+    [%%endif]
   end
 
   module Flag : sig

--- a/lib/kqueue_stubs.c
+++ b/lib/kqueue_stubs.c
@@ -97,6 +97,17 @@
     CAMLreturn(Val_long(ret));
   }
 
+  #ifdef EVFILT_USER_AVAILABLE
+    Kqueue_constant(kqueue_filter_evfilt_user, EVFILT_USER)
+    Kqueue_constant(kqueue_note_ffnop, NOTE_FFNOP)
+    Kqueue_constant(kqueue_note_ffand, NOTE_FFAND)
+    Kqueue_constant(kqueue_note_ffor, NOTE_FFOR)
+    Kqueue_constant(kqueue_note_ffcopy, NOTE_FFCOPY)
+    Kqueue_constant(kqueue_note_ffctrlmask, NOTE_FFCTRLMASK)
+    Kqueue_constant(kqueue_note_fflagsmask, NOTE_FFLAGSMASK)
+    Kqueue_constant(kqueue_note_trigger, NOTE_TRIGGER)
+  #endif 
+
   Kqueue_constant(kqueue_filter_evfilt_read, EVFILT_READ)
   Kqueue_constant(kqueue_filter_evfilt_write, EVFILT_WRITE)
   Kqueue_constant(kqueue_filter_evfilt_timer, EVFILT_TIMER)


### PR DESCRIPTION
Support EVFILT_USER supported systems. macOS and FreeBSD support this filter, but openbsd doesn't. We can use dune-configurator to probe weather the host OS supports EVFILT_USER and conditionally enable this filter along with the list of fflags supported for this filter.

cc @rgrinberg